### PR TITLE
switch from ITWOM to vanilla ITM model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 .DS_Store
 .idea/
 *.tiff
+*.tif
 *.pyc
 log.txt
 *.log
@@ -40,3 +41,5 @@ dist-ssr
 *.sln
 *.sw?
 .vite
+app/ui/assets/*.css
+app/ui/assets/*.js

--- a/app/services/splat.py
+++ b/app/services/splat.py
@@ -211,7 +211,8 @@ class Splat:
                     "-db",
                     str(request.signal_threshold),
                     "-kml",
-                ]
+                    "-olditm"
+                ] # flag "olditm" uses the standard ITM model instead of ITWOM, which has produced unrealistic results.
                 logger.debug(f"Executing SPLAT! command: {' '.join(splat_command)}")
 
                 splat_result = subprocess.run(
@@ -773,24 +774,24 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     try:
         splat_service = Splat(
-            splat_path="splat",  # Replace with the actual SPLAT! binary path
+            splat_path="",  # Replace with the actual SPLAT! binary path
         )
 
         # Create a test coverage prediction request
         test_coverage_request = CoveragePredictionRequest(
-            lat=-37.8136,
-            lon=144.9631,
-            tx_height=5.0,
+            lat=51.4408448,
+            lon=-0.8994816,
+            tx_height=1.0,
             ground_dielectric=15.0,
             ground_conductivity=0.005,
             atmosphere_bending=301.0,
-            frequency_mhz=905.0,
+            frequency_mhz=868.0,
             radio_climate="continental_temperate",
             polarization="vertical",
-            situation_fraction=90.0,
-            time_fraction=90.0,
+            situation_fraction=95.0,
+            time_fraction=95.0,
             tx_power=30.0,
-            tx_gain=2.0,
+            tx_gain=1.0,
             system_loss=2.0,
             rx_height=1.0,
             radius=50000.0,

--- a/app/ui/index.html
+++ b/app/ui/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <title>Meshtastic Site Planner</title>
-    <script type="module" crossorigin src="/assets/index-C1ENZROj.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-CujURarT.css">
+    <script type="module" crossorigin src="/assets/index--A8XCeRz.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DtImDtOG.css">
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
This change enables the `-olditm` flag on the backend, which should fix the overly optimistic predictions in EU868. Also, reliability defaults in the backend are set to 95 percent for time and situation thresholds to align with the old tool and defaults in the UI.

See: https://github.com/meshtastic/meshtastic-site-planner/issues/19

