### PR TITLE
feat: add common meshtastic device presets to transmitter and receivers

### DIFF
--- a/src/components/Receiver.vue
+++ b/src/components/Receiver.vue
@@ -1,10 +1,20 @@
-
 <template>
     <form novalidate>
+        <div class="row g-2 mb-2">
+            <div class="col-12">
+                <label for="rx_preset" class="form-label">Device Preset</label>
+                <select v-model="selectedPreset" @change="applyPreset" class="form-select form-select-sm" id="rx_preset">
+                    <option v-for="device in meshtasticDevices" :key="device.id" :value="device">
+                        {{ device.name }}
+                    </option>
+                </select>
+            </div>
+        </div>
+
         <div class="row g-2">
             <div class="col-6">
                 <label for="rx_sensitivity" class="form-label">Sensitivity (dBm)</label>
-                <input v-model="receiver.rx_sensitivity" type="number" class="form-control form-control-sm" id="rx_sensitivity" required step="1" min="-150" max="-30" />
+                <input v-model="receiver.rx_sensitivity" @input="setCustom" type="number" class="form-control form-control-sm" id="rx_sensitivity" required step="1" min="-150" max="-30" />
             <div class="invalid-feedback">Please enter a valid sensitivity.</div>
             </div>
                 <div class="col-6">
@@ -16,7 +26,7 @@
             <div class="row g-2 mt-2">
                 <div class="col-6">
                 <label for="rx_gain" class="form-label">Antenna Gain (dB)</label>
-                <input v-model="receiver.rx_gain" type="number" class="form-control form-control-sm" id="rx_gain" required min="0" max="30" step="0.1" />
+                <input v-model="receiver.rx_gain" @input="setCustom" type="number" class="form-control form-control-sm" id="rx_gain" required min="0" max="30" step="0.1" />
                 <div class="invalid-feedback">Gain must be a positive number.</div>
             </div>
             <div class="col-6">
@@ -29,6 +39,26 @@
 </template>
 
 <script setup lang="ts">
-    import { useStore } from '../store.ts'
-    const receiver = useStore().splatParams.receiver
+    import { ref } from 'vue';
+    import { useStore } from '../store.ts';
+    import { meshtasticDevices } from '../devicePresets.ts';
+
+    const store = useStore();
+    const receiver = store.splatParams.receiver;
+
+    // State for the dropdown
+    const selectedPreset = ref(meshtasticDevices[0]);
+
+    // Apply the preset values
+    const applyPreset = () => {
+        if (selectedPreset.value.id !== 'custom') {
+            receiver.rx_sensitivity = selectedPreset.value.rx_sensitivity!;
+            receiver.rx_gain = selectedPreset.value.rx_gain!;
+        }
+    };
+
+    // If a user manually changes a pre-filled field, flip dropdown back to "Custom"
+    const setCustom = () => {
+        selectedPreset.value = meshtasticDevices[0];
+    };
 </script>

--- a/src/components/Transmitter.vue
+++ b/src/components/Transmitter.vue
@@ -1,13 +1,24 @@
-
 <template>
     <form novalidate>
+        <div class="row g-2 mb-2">
+            <div class="col-12">
+                <label for="tx_preset" class="form-label">Device Preset</label>
+                <select v-model="selectedPreset" @change="applyPreset" class="form-select form-select-sm" id="tx_preset">
+                    <option v-for="device in meshtasticDevices" :key="device.id" :value="device">
+                        {{ device.name }}
+                    </option>
+                </select>
+            </div>
+        </div>
+
         <div class="row g-2">
             <div class="col-12">
                 <label for="name" class="form-label">Site name</label>
                 <input v-model="transmitter.name" class="form-control form-control-sm" id="name" required data-bs-toggle="tooltip" title="Site Name" />
             </div>
         </div>
-        <div class="row g-2">
+        
+        <div class="row g-2 mt-2">
             <div class="col-6">
                 <label for="tx_lat" class="form-label">Latitude (degrees)</label>
                 <input v-model="transmitter.tx_lat" type="number" class="form-control form-control-sm" id="tx_lat" required min="-90" max="90" step="0.000001" data-bs-toggle="tooltip" title="Transmitter latitude in degrees (-90 to 90)." />
@@ -19,10 +30,11 @@
                 <div class="invalid-feedback">Please enter a valid longitude (-180 to 180).</div>
             </div>
         </div>
+        
         <div class="row g-2 mt-2">
             <div class="col-6">
                 <label for="tx_power" class="form-label">Power (W)</label>
-                <input v-model="transmitter.tx_power" type="number" class="form-control form-control-sm" id="tx_power" required min="0" step="0.1" data-bs-toggle="tooltip" title="Transmitter power in watts (>0)." />
+                <input v-model="transmitter.tx_power" @input="setCustom" type="number" class="form-control form-control-sm" id="tx_power" required min="0" step="0.1" data-bs-toggle="tooltip" title="Transmitter power in watts (>0)." />
                 <div class="invalid-feedback">Power must be a positive number.</div>
             </div>
             <div class="col-6">
@@ -39,7 +51,7 @@
             </div>
             <div class="col-6">
                 <label for="tx_gain" class="form-label">Antenna Gain (dB)</label>
-                <input v-model="transmitter.tx_gain" type="number" class="form-control form-control-sm" id="tx_gain" required min="0" step="0.1" />
+                <input v-model="transmitter.tx_gain" @input="setCustom" type="number" class="form-control form-control-sm" id="tx_gain" required min="0" step="0.1" />
                 <div class="invalid-feedback">Gain must be a positive number.</div>
             </div>
         </div>
@@ -53,21 +65,40 @@
 </template>
 
 <script setup lang="ts">
+    import { ref, onMounted } from 'vue';
     import L from 'leaflet';
     import * as bootstrap from 'bootstrap';
     import { useStore } from '../store.ts'
-    import { onMounted } from 'vue';
     import { redPinMarker } from '../layers.ts';
+    import { meshtasticDevices } from '../devicePresets.ts';
+
     const store = useStore();
     const transmitter = store.splatParams.transmitter;
+    
+    // State for the dropdown
+    const selectedPreset = ref(meshtasticDevices[0]);
+
+    // Apply the preset values
+    const applyPreset = () => {
+        if (selectedPreset.value.id !== 'custom') {
+            transmitter.tx_power = selectedPreset.value.tx_power!;
+            transmitter.tx_gain = selectedPreset.value.tx_gain!;
+        }
+    };
+
+    // If a user manually changes a pre-filled field, flip dropdown back to "Custom"
+    const setCustom = () => {
+        selectedPreset.value = meshtasticDevices[0];
+    };
 
     const centerMapOnTransmitter = () => {
         if (!isNaN(transmitter.tx_lat) && !isNaN(transmitter.tx_lon)) {
-            store.map!.setView([transmitter.tx_lat, transmitter.tx_lon], store.map!.getZoom()); // Center map on the coordinates
+            store.map!.setView([transmitter.tx_lat, transmitter.tx_lon], store.map!.getZoom()); 
         } else {
             alert("Please enter valid Latitude and Longitude values.");
         }
     };
+
     let popover = new bootstrap.Popover(document.createElement("input"), {
         trigger: "manual",
     });
@@ -75,25 +106,23 @@
     const setWithMap = () => {
         popover.show();
         store.map!.once("click", function (e: any) {
-            let { lat, lng } = e.latlng; // Get clicked location coordinates
+            let { lat, lng } = e.latlng;
             lng = ((((lng + 180) % 360) + 360) % 360) - 180;
 
-            store.setTxCoords(lat.toFixed(6), lng.toFixed(6)); // Update the store
+            store.setTxCoords(lat.toFixed(6), lng.toFixed(6));
 
-            // Remove the existing marker if it exists
             if (store.currentMarker) {
                 store.map!.removeLayer(store.currentMarker as L.Marker);
             }
-            // Add a new marker at the clicked location
             store.currentMarker = L.marker([lat, lng], { icon: redPinMarker }).addTo(store.map as L.Map)
-            popover.hide(); // Hide the popover
+            popover.hide();
         });
     };
+
     onMounted(() => {
         popover = new bootstrap.Popover(document.getElementById("setWithMap") as Element, {
             trigger: "manual",
         });
-        store.initMap(); // Initialize the map
+        store.initMap();
     });
-
 </script>

--- a/src/devicePresets.ts
+++ b/src/devicePresets.ts
@@ -1,0 +1,234 @@
+export interface DevicePreset {
+    id: string;
+    name: string;
+    tx_power: number | null; // Watts
+    tx_gain: number | null;  // dB
+    rx_sensitivity: number | null; // dB
+    rx_gain: number | null;  // dB
+}
+
+export const meshtasticDevices: DevicePreset[] = [
+    {
+        id: 'custom',
+        name: 'Custom / Manual Entry',
+        tx_power: 0.1,
+        tx_gain: 2,
+        rx_sensitivity: -130,
+        rx_gain: 2
+    },
+    // RAK
+    {
+        id: 'rak_wisblock_4631',
+        name: 'RAK WisBlock Core RAK4631 (Assumed 2dBi Antenna)',
+        tx_power: 0.158,
+        tx_gain: 2.0,
+        rx_sensitivity: -130,
+        rx_gain: 2.0
+    },
+    {
+        id: 'rak_wisblock_11310',
+        name: 'RAK WisBlock Core RAK11310 (Assumed 2dBi Antenna)',
+        tx_power: 0.158,
+        tx_gain: 2.0,
+        rx_sensitivity: -130,
+        rx_gain: 2.0
+    },
+    {
+        id: 'rak_wisblock_3312',
+        name: 'RAK WisBlock Core RAK3312 (Assumed 2dBi Antenna)',
+        tx_power: 0.158,
+        tx_gain: 2.0,
+        rx_sensitivity: -130,
+        rx_gain: 2.0
+    },
+    {
+        id: 'rak_wismesh_pocket_v2',
+        name: 'RAK WisMesh Pocket V2 (Stock Antenna)',
+        tx_power: 0.158,
+        tx_gain: 2.0,
+        rx_sensitivity: -130,
+        rx_gain: 2.0
+    },
+    {
+        id: 'rak_wismesh_pocket_mini',
+        name: 'RAK WisMesh Pocket Mini (Internal Antenna)',
+        tx_power: 0.158,
+        tx_gain: 1.0,
+        rx_sensitivity: -130,
+        rx_gain: 1.0
+    },
+    {
+        id: 'rak_wismesh_tag',
+        name: 'RAK WisMesh Tag (Internal Antenna)',
+        tx_power: 0.158,
+        tx_gain: 1.0,
+        rx_sensitivity: -130,
+        rx_gain: 1.0
+    },
+    {
+        id: 'rak_wismesh_1w_booster',
+        name: 'RAK WisMesh 1W Booster (Assumed 2dBi Antenna)',
+        tx_power: 1.0,
+        tx_gain: 2.0,
+        rx_sensitivity: -130,
+        rx_gain: 2.0
+    },
+    // LILYGO
+    {
+        id: 'lilygo_tbeam_s3',
+        name: 'LILYGO T-Beam S3-Core (Assumed 2dBi Antenna)',
+        tx_power: 0.158,
+        tx_gain: 2.0,
+        rx_sensitivity: -130,
+        rx_gain: 2.0
+    },
+    {
+        id: 'lilygo_techo',
+        name: 'LILYGO T-Echo (Internal Antenna)',
+        tx_power: 0.158,
+        tx_gain: 1.0,
+        rx_sensitivity: -130,
+        rx_gain: 1.0
+    },
+    {
+        id: 'lilygo_tdeck',
+        name: 'LILYGO T-Deck (Internal Antenna)',
+        tx_power: 0.158,
+        tx_gain: 1.0,
+        rx_sensitivity: -130,
+        rx_gain: 1.0
+    },
+    {
+        id: 'lilygo_tdeck_plus',
+        name: 'LILYGO T-Deck Plus (Internal Antenna)',
+        tx_power: 0.158,
+        tx_gain: 1.0,
+        rx_sensitivity: -130,
+        rx_gain: 1.0
+    },
+    {
+        id: 'lilygo_tdeck_pro',
+        name: 'LILYGO T-Deck Pro (Internal Antenna)',
+        tx_power: 0.158,
+        tx_gain: 1.0,
+        rx_sensitivity: -130,
+        rx_gain: 1.0
+    },
+    // HelTec
+    {
+        id: 'heltec_lora32_v3',
+        name: 'HelTec LoRa 32 V3 (Assumed 2dBi Antenna)',
+        tx_power: 0.126,
+        tx_gain: 2.0,
+        rx_sensitivity: -134,
+        rx_gain: 2.0
+    },
+    {
+        id: 'heltec_lora32_v4',
+        name: 'HelTec LoRa 32 V4 (Assumed 2dBi Antenna)',
+        tx_power: 0.158,
+        tx_gain: 2.0,
+        rx_sensitivity: -137,
+        rx_gain: 2.0
+    },
+    {
+        id: 'heltec_meshpocket',
+        name: 'HelTec MeshPocket (Internal Antenna)',
+        tx_power: 0.158,
+        tx_gain: 1.0,
+        rx_sensitivity: -130,
+        rx_gain: 1.0
+    },
+    // Seeed Studio
+    {
+        id: 'seeed_sensecap_t1000e',
+        name: 'Seeed Studio SenseCAP Card Tracker T1000-E (Internal Antenna)',
+        tx_power: 0.158,
+        tx_gain: 1.0,
+        rx_sensitivity: -130,
+        rx_gain: 1.0
+    },
+    {
+        id: 'seeed_sensecap_solar',
+        name: 'Seeed Studio SenseCAP Solar Node (Assumed 2dBi Antenna)',
+        tx_power: 0.158,
+        tx_gain: 2.0,
+        rx_sensitivity: -130,
+        rx_gain: 2.0
+    },
+    {
+        id: 'seeed_wio_l1',
+        name: 'Seeed Studio Wio Tracker L1 (Stock Antenna)',
+        tx_power: 0.158,
+        tx_gain: 2.0,
+        rx_sensitivity: -130,
+        rx_gain: 2.0
+    },
+    // B&Q Consulting
+    {
+        id: 'bq_nano_g2_ultra',
+        name: 'B&Q Consulting Nano G2 Ultra (Stock Antenna)',
+        tx_power: 0.158,
+        tx_gain: 2.0,
+        rx_sensitivity: -130,
+        rx_gain: 2.0
+    },
+    {
+        id: 'bq_station_g2',
+        name: 'B&Q Consulting Station G2 (Included 18.5dBi Antenna)',
+        tx_power: 4.46,
+        tx_gain: 18.5,
+        rx_sensitivity: -130,
+        rx_gain: 18.5
+    },
+    // Elecrow
+    {
+        id: 'elecrow_thinknode_m1',
+        name: 'Elecrow ThinkNode M1 (Stock Antenna)',
+        tx_power: 0.158,
+        tx_gain: 2.5,
+        rx_sensitivity: -130,
+        rx_gain: 2.5
+    },
+    {
+        id: 'elecrow_thinknode_m2',
+        name: 'Elecrow ThinkNode M2 (Stock Antenna)',
+        tx_power: 0.158,
+        tx_gain: 2.0,
+        rx_sensitivity: -130,
+        rx_gain: 2.0
+    },
+    {
+        id: 'elecrow_thinknode_m3',
+        name: 'Elecrow ThinkNode M3 (Internal Antenna)',
+        tx_power: 0.158,
+        tx_gain: 1.0,
+        rx_sensitivity: -130,
+        rx_gain: 1.0
+    },
+    // muzi works
+    {
+        id: 'muzi_r1_neo',
+        name: 'muzi works R1 Neo (Stock Antenna)',
+        tx_power: 0.158,
+        tx_gain: 3.5,
+        rx_sensitivity: -130,
+        rx_gain: 3.5
+    },
+    {
+        id: 'muzi_base_uno',
+        name: 'muzi works Base Uno (Assumed 2dBi Antenna)',
+        tx_power: 0.158,
+        tx_gain: 2.0,
+        rx_sensitivity: -130,
+        rx_gain: 2.0
+    },
+    {
+        id: 'muzi_base_duo',
+        name: 'muzi works Base Duo (Assumed 2dBi Antenna)',
+        tx_power: 0.158,
+        tx_gain: 2.0,
+        rx_sensitivity: -130,
+        rx_gain: 2.0
+    }
+];


### PR DESCRIPTION
Added a dropdown menu on the transmitters and receivers panels to allow users to select from a predefined list of common devices. Devices can be updated from the device presets file.

Fixes #51 